### PR TITLE
Implement historic result detail

### DIFF
--- a/app/src/main/java/com/example/quince/navcontroller/Rutas.kt
+++ b/app/src/main/java/com/example/quince/navcontroller/Rutas.kt
@@ -5,4 +5,5 @@ sealed class Rutas (val ruta : String){
     object SegundaPantalla : Rutas("segunda")
     object Principal: Rutas ("principal")
     object Historial: Rutas ("historial")
+    object DetalleHistorial: Rutas("detalleHistorial")
 }

--- a/app/src/main/java/com/example/quince/navcontroller/navhost.kt
+++ b/app/src/main/java/com/example/quince/navcontroller/navhost.kt
@@ -7,6 +7,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.example.quince.pantallas.Historial
+import com.example.quince.pantallas.DetalleHistorial
 import com.example.quince.pantallas.Primera
 import com.example.quince.pantallas.Principal
 import com.example.quince.pantallas.Segunda
@@ -36,6 +37,13 @@ fun AppNavHost(navController: NavHostController) {
         }
         composable(route = Rutas.Historial.ruta) {
             Historial(navController = navController)
+        }
+        composable(
+            route = "${Rutas.DetalleHistorial.ruta}/{provinciaId}",
+            arguments = listOf(navArgument("provinciaId") { type = NavType.IntType })
+        ) { backStackEntry ->
+            val provinciaId = backStackEntry.arguments?.getInt("provinciaId") ?: -1
+            DetalleHistorial(navController = navController, provinciaId = provinciaId)
         }
     }}
 //En el NavHost indico las pantallas que habrá. Es un contenedor de pantallas y se usa para navegar entre ellas.

--- a/app/src/main/java/com/example/quince/pantallas/detallehistorial.kt
+++ b/app/src/main/java/com/example/quince/pantallas/detallehistorial.kt
@@ -1,0 +1,44 @@
+package com.example.quince.pantallas
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.example.quince.model.Provincias
+import com.example.quince.room.historialviewmodel.DetalleHistorialViewModel
+import com.google.gson.Gson
+
+@Composable
+fun DetalleHistorial(
+    navController: NavController,
+    provinciaId: Int,
+    viewModel: DetalleHistorialViewModel = viewModel()
+) {
+    LaunchedEffect(provinciaId) {
+        viewModel.cargarTiempoPorProvinciaId(provinciaId)
+    }
+
+    val tiempoState by viewModel.tiempo.collectAsState()
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(
+                Brush.verticalGradient(
+                    colors = listOf(gradientStartColor, gradientEndColor)
+                )
+            )
+    ) {
+        tiempoState?.let { tiempo ->
+            val provincias = Gson().fromJson(tiempo.dataJson, Provincias::class.java)
+            SuccessState(provincias, tiempo.Recomendado, navController)
+        } ?: LoadingState()
+    }
+}

--- a/app/src/main/java/com/example/quince/pantallas/historial.kt
+++ b/app/src/main/java/com/example/quince/pantallas/historial.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.ArrowBackIosNew
@@ -50,6 +51,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.example.quince.room.dataclasses.Provincia
 import com.example.quince.room.historialviewmodel.HistorialViewModel
+import com.example.quince.navcontroller.Rutas
 
 
 //Gemini
@@ -100,7 +102,9 @@ fun Historial(
                     contentPadding = PaddingValues(bottom = 16.dp) // Espacio para que el último item no pegue con el botón
                 ) {
                     items(provincias, key = { provincia -> provincia.id }) { provincia -> // Usa un 'key' si tus provincias tienen ID único
-                        HistoryItemCard(provincia = provincia)
+                        HistoryItemCard(provincia = provincia) {
+                            navController.navigate("${Rutas.DetalleHistorial.ruta}/${provincia.id}")
+                        }
                     }
                 }
             }
@@ -116,11 +120,12 @@ fun Historial(
 }
 
 @Composable
-fun HistoryItemCard(provincia: Provincia) {
+fun HistoryItemCard(provincia: Provincia, onClick: () -> Unit) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .heightIn(min = 70.dp), // Altura mínima para la tarjeta
+            .heightIn(min = 70.dp) // Altura mínima para la tarjeta
+            .clickable { onClick() },
         shape = RoundedCornerShape(16.dp),
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
         colors = CardDefaults.cardColors(containerColor = cardBackgroundColor)

--- a/app/src/main/java/com/example/quince/pantallas/segunda.kt
+++ b/app/src/main/java/com/example/quince/pantallas/segunda.kt
@@ -125,7 +125,7 @@ fun Segunda(
                         db.daoProvincia().insertProvincia(provinciaAVerSiAhora)
                     } catch (e: Exception) { /* ... */ }
 
-                    val nombreId = db.daoProvincia().getIdByName(nombreProvincia.decodeUnicodeCompletely())
+                    val nombreId = db.daoProvincia().getLastIdByName(nombreProvincia.decodeUnicodeCompletely())
                     val provinciaNombreDecodedForDb = successData.provincia.NOMBRE_PROVINCIA.decodeUnicodeCompletely()
                     val ciudadIdParaCompararForDb = paresProvCod[provinciaNombreDecodedForDb]
                     val ciudadEncontradaForDb = successData.ciudades?.firstOrNull { ciudad ->
@@ -156,6 +156,7 @@ fun Segunda(
                     }
                     consejo = recomendacionProvincia?.consejos?.decodeUnicodeCompletely() ?: "Sin recomendación disponible."
                     recomendacionId = recomendacionProvincia?.id
+                    val jsonData = com.google.gson.Gson().toJson(successData)
                     val tiempoAVer = Tiempo(
                         provincia = nombreProvincia.decodeUnicodeCompletely(),
                         provinciaId = nombreId ?: -1,
@@ -163,7 +164,8 @@ fun Segunda(
                         maxTemp = maxTemp?.toDoubleOrNull() ?: 0.0,
                         minTemp = minTemp?.toDoubleOrNull() ?: 0.0,
                         Recomendado = consejo ?: "Sin recomendación",
-                        consejoId = recomendacionId ?: -1
+                        consejoId = recomendacionId ?: -1,
+                        dataJson = jsonData
                     )
                     try {
                         db.daoTiempo().insertTiempo(tiempoAVer)

--- a/app/src/main/java/com/example/quince/room/daos/DaoProvincia.kt
+++ b/app/src/main/java/com/example/quince/room/daos/DaoProvincia.kt
@@ -21,6 +21,10 @@ interface DaoProvincia {
     @Query("SELECT id FROM provincia WHERE name = :provinciaName LIMIT 1")
     suspend fun getIdByName(provinciaName: String): Int?
 
+    // Devuelve el id de la última provincia insertada con ese nombre
+    @Query("SELECT id FROM provincia WHERE name = :provinciaName ORDER BY id DESC LIMIT 1")
+    suspend fun getLastIdByName(provinciaName: String): Int?
+
     //Sacar las últimas 5 provincias para mostrar en el historial
     @Query("SELECT * FROM provincia ORDER BY id DESC LIMIT 5")
     suspend fun getUltimasProvincias(): List<Provincia>

--- a/app/src/main/java/com/example/quince/room/daos/DaoTiempo.kt
+++ b/app/src/main/java/com/example/quince/room/daos/DaoTiempo.kt
@@ -17,6 +17,10 @@ interface DaoTiempo {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertTiempo(tiempo: Tiempo)
 
+    // Obtiene el registro de tiempo asociado a una provincia concreta
+    @Query("SELECT * FROM tiempo WHERE provinciaId = :provinciaId LIMIT 1")
+    suspend fun getTiempoByProvinciaId(provinciaId: Int): Tiempo?
+
 
     @Transaction
     suspend fun insertarRecomendaciónRango(

--- a/app/src/main/java/com/example/quince/room/database/AppDatabase.kt
+++ b/app/src/main/java/com/example/quince/room/database/AppDatabase.kt
@@ -14,7 +14,7 @@ import com.example.quince.room.dataclasses.Tiempo
 
 @Database(
     entities = [Provincia::class, Recomendacion::class, Tiempo::class],
-    version = 7,
+    version = 8,
     exportSchema = false)
 abstract class AppDatabase : RoomDatabase() {
     // Aquí van las instancias de los DAO que permiten interactuar con las tablas de la base de datos.

--- a/app/src/main/java/com/example/quince/room/dataclasses/Tiempo.kt
+++ b/app/src/main/java/com/example/quince/room/dataclasses/Tiempo.kt
@@ -36,5 +36,7 @@ data class Tiempo(
     @ColumnInfo(name = "recomendado")
     val Recomendado: String,
     @ColumnInfo(name = "consejoId")
-    val consejoId: Int
+    val consejoId: Int,
+    @ColumnInfo(name = "dataJson")
+    val dataJson: String
 )

--- a/app/src/main/java/com/example/quince/room/historialviewmodel/DetalleHistorialViewModel.kt
+++ b/app/src/main/java/com/example/quince/room/historialviewmodel/DetalleHistorialViewModel.kt
@@ -1,0 +1,25 @@
+package com.example.quince.room.historialviewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.quince.room.database.AppDatabase.Companion.getDatabase
+import com.example.quince.room.dataclasses.Tiempo
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class DetalleHistorialViewModel(application: Application) : AndroidViewModel(application) {
+    private val tiempoDao = getDatabase(application).daoTiempo()
+
+    private val _tiempo = MutableStateFlow<Tiempo?>(null)
+    val tiempo: StateFlow<Tiempo?> = _tiempo
+
+    fun cargarTiempoPorProvinciaId(provinciaId: Int) {
+        viewModelScope.launch(Dispatchers.IO) {
+            val data = tiempoDao.getTiempoByProvinciaId(provinciaId)
+            _tiempo.value = data
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend navigation for new screen 'DetalleHistorial'
- store whole API response in Tiempo table
- fetch stored data with new DAO and ViewModel
- make historial entries clickable to open past result

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841dd1f9654832ea582971ab1a4ac5b